### PR TITLE
Feat: Select multiple viewport using viewportCategory filter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 node_modules
 coverage
 dist
-__tests__

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ coverage
 dist
 
 # Output folders
-**/output/*
-!**/output/.gitkeep
+output

--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ await capture.capture('https://github.com/b4dnewz', {
 });
 ```
 
+#### Capture all viewport by category
+
+Capture a page in multiple viewports filtered by category.
+
+```js
+// By hard-coded category filter
+await capture.capture('https://github.com/b4dnewz', {
+  viewportCategory: 'mobile'
+});
+
+// By custom name string match
+await capture.capture('https://github.com/b4dnewz', {
+  viewportCategory: 'nexus'
+});
+```
+
 ---
 
 ## License

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,167 +1,187 @@
-import * as _ from 'lodash'
+import * as _ from 'lodash';
 import * as fs from 'fs';
 import * as path from 'path';
 import WebpageCapture from '../lib/index';
 
 const capturer = new WebpageCapture({
-  outputDir: path.resolve(__dirname, './output'),
-  viewport: 'non-existing',
-  headers: {
-    Test: 'foo'
-  }
+	outputDir: path.resolve(__dirname, './output'),
+	viewport: 'non-existing',
+	headers: {
+		Test: 'foo'
+	}
 });
 
-const outputCollector = [];
+let outputCollector = [];
 
-describe('WebpageCapture', () => {
-  jest.setTimeout(10000);
+describe('webpage-capture', () => {
+	jest.setTimeout(10000);
 
-  const prepare = jest.spyOn(capturer, 'prepare')
+	const prepare = jest.spyOn(capturer, 'prepare');
 
-  afterAll(async () => {
-    await capturer.close();
-    _.flatten(outputCollector)
-      .forEach(f => fs.unlinkSync(f));
-  });
+	afterAll(async () => {
+		await capturer.close();
+		_.flatten(outputCollector)
+			.forEach(f => fs.unlinkSync(f));
+	});
 
-  it('calls the prepare function', async () => {
-    const res = await capturer.capture('about:blank')
-    outputCollector.push(res[0].path);
-    expect(prepare).toHaveBeenCalled()
-  })
+	it('calls the prepare function', async () => {
+		const res = await capturer.capture('about:blank');
+		outputCollector.push(res[0].path);
+		expect(prepare).toHaveBeenCalled();
+	});
 
-  it('fall back to default viewport', () => {
-    expect(capturer.options).toMatchObject({
-      viewport: false
-    });
-  });
+	it('fall back to default viewport', () => {
+		expect(capturer.options).toMatchObject({
+			viewport: false
+		});
+	});
 
-  describe('viewports', () => {
-    it('supports format 0000x0000 or 0000', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        viewport: '200x200'
-      });
-      outputCollector.push(res[0].path);
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.any(String)
-      });
-    });
+	describe('viewports', () => {
+		it('supports format 0000x0000 or 0000', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				viewport: '200x200'
+			});
+			outputCollector.push(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.any(String)
+			});
+		});
 
-    it('supports format as object', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        viewport: {
-          width: 600,
-          height: 400
-        }
-      });
-      outputCollector.push(res[0].path);
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.any(String)
-      });
-    });
+		it('supports format as object', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				viewport: {
+					width: 600,
+					height: 400
+				}
+			});
+			outputCollector.push(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.any(String)
+			});
+		});
 
-    it('supports format as number', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        viewport: 350
-      });
-      outputCollector.push(res[0].path);
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.any(String)
-      });
-    });
-  });
+		it('supports format as number', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				viewport: 350
+			});
+			outputCollector.push(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.any(String)
+			});
+		});
 
-  describe('capture', () => {
-    it('returns if no input', async () => {
-      await expect(capturer.capture()).resolves.toBeUndefined();
-      await expect(capturer.capture('')).resolves.toBeUndefined();
-      await expect(capturer.capture([])).resolves.toBeUndefined();
-    });
+		it('support viewports by category', async () => {
+			const testUrl = 'about:blank';
+			const res = await capturer.capture(testUrl, {
+				viewportCategory: 'desktop'
+			});
+			outputCollector = outputCollector.concat(res[0].path);
+			expect(res.length).not.toBe(0);
+			expect(res[0].path).not.toBe(0);
+		});
 
-    it('accept multiple sources', async () => {
-      const testUrls = ['http://google.com', 'http://example.com', 'http://google.com'];
-      const res = await capturer.capture(testUrls);
-      outputCollector.push(res.map(r => r.path));
-      expect(res.length).toBe(2);
-      expect(res[0]).toMatchObject({
-        url: testUrls[0]
-      });
-      expect(res[1]).toMatchObject({
-        url: testUrls[1]
-      });
-    });
+		it('support viewports filtering category by name', async () => {
+			const testUrl = 'about:blank';
+			const res = await capturer.capture(testUrl, {
+				viewportCategory: 'blackberry'
+			});
+			outputCollector = outputCollector.concat(res[0].path);
+			expect(res.length).not.toBe(0);
+			expect(res[0].path).not.toBe(0);
+		});
+	});
 
-    it('accept html text', async () => {
-      const res = await capturer.capture('<h1>testing</h1>');
-      outputCollector.push(res[0].path);
-      expect(res).toBeDefined();
-    });
+	describe('capture', () => {
+		it('returns if no input', async () => {
+			await expect(capturer.capture()).resolves.toBeUndefined();
+			await expect(capturer.capture('')).resolves.toBeUndefined();
+			await expect(capturer.capture([])).resolves.toBeUndefined();
+		});
 
-    it('capture output as pdf', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        type: 'pdf'
-      });
-      outputCollector.push(res[0].path);
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.stringContaining('.pdf')
-      });
-    });
+		it('removes duplicate from sources input', async () => {
+			const testUrls = ['http://google.com', 'http://example.com', 'http://google.com'];
+			const res = await capturer.capture(testUrls);
+			outputCollector = outputCollector.concat(res.map(r => r.path));
+			expect(res.length).toBe(2);
+			expect(res[0]).toMatchObject({
+				url: testUrls[0]
+			});
+			expect(res[1]).toMatchObject({
+				url: testUrls[1]
+			});
+		});
 
-    it('capture output as html', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        type: 'html'
-      });
-      outputCollector.push(res[0].path);
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.stringContaining('.html')
-      });
-    });
+		it('accept html text', async () => {
+			const res = await capturer.capture('<h1>testing</h1>');
+			outputCollector.push(res[0].path);
+			expect(res).toBeDefined();
+		});
 
-    it('capture multiple viewports at once', async () => {
-      const testUrl = 'http://google.com';
-      const res = await capturer.capture(testUrl, {
-        viewport: ['desktop-firefox', 'desktop-safari']
-      });
-      outputCollector.push(res.map(r => r.path));
-      expect(res[0]).toMatchObject({
-        url: testUrl,
-        path: expect.any(Array)
-      });
-    }, 10000);
+		it('capture output as pdf', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				type: 'pdf'
+			});
+			outputCollector.push(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.stringContaining('.pdf')
+			});
+		});
 
-    it('support scripts loading', async () => {
-      const testUrl = 'http://example.com';
-      const res = await capturer.capture(testUrl, {
-        scripts: [
-          'window.foo = "bar"'
-        ]
-      });
-      outputCollector.push(res[0].path);
-      await expect(
-        capturer.page.evaluate(() => window.foo)
-      ).resolves.toEqual('bar');
-    });
+		it('capture output as html', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				type: 'html'
+			});
+			outputCollector.push(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.stringContaining('.html')
+			});
+		});
 
-    it('support styles loading', async () => {
-      const res = await capturer.capture('about:blank', {
-        styles: [
-          'body { background-color: red; }'
-        ]
-      });
-      outputCollector.push(res[0].path);
-      await expect(
-        capturer.page.evaluate(() => window.document.querySelector('style').textContent)
-      ).resolves.toMatch('background-color: red;');
-    });
-  });
+		it('capture multiple viewports at once', async () => {
+			const testUrl = 'http://google.com';
+			const res = await capturer.capture(testUrl, {
+				viewport: ['desktop-firefox', 'desktop-safari']
+			});
+			outputCollector = outputCollector.concat(res[0].path);
+			expect(res[0]).toMatchObject({
+				url: testUrl,
+				path: expect.any(Array)
+			});
+		}, 10000);
+
+		it('support scripts loading', async () => {
+			const testUrl = 'http://example.com';
+			const res = await capturer.capture(testUrl, {
+				scripts: [
+					'window.foo = "bar"'
+				]
+			});
+			outputCollector.push(res[0].path);
+			await expect(
+				capturer.page.evaluate(() => window.foo)
+			).resolves.toEqual('bar');
+		});
+
+		it('support styles loading', async () => {
+			const res = await capturer.capture('about:blank', {
+				styles: [
+					'body { background-color: red; }'
+				]
+			});
+			outputCollector.push(res[0].path);
+			await expect(
+				capturer.page.evaluate(() => window.document.querySelector('style').textContent)
+			).resolves.toMatch('background-color: red;');
+		});
+	});
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,57 @@
+import prepareViewports from '../lib/utils/prepare-viewports';
+import prepareArguments from '../lib/utils/prepare-arguments';
+
+import * as fs from 'fs';
+
+jest.mock('fs', () => ({
+	readFileSync: jest.fn().mockImplementation(value => value)
+}));
+
+describe('webpage-capture:utils', () => {
+	describe('prepare-arguments', () => {
+		afterEach(() => {
+			fs.readFileSync.mockClear();
+		});
+
+		it('return arguments if urls', () => {
+			const args = ['http://google.it'];
+			expect(prepareArguments(args)).toEqual(args);
+		});
+
+		it('tries to load html files content', () => {
+			prepareArguments([
+				'some/path/to/index.html'
+			]);
+			expect(fs.readFileSync).toHaveBeenCalled();
+			expect(fs.readFileSync).toHaveBeenCalledWith('some/path/to/index.html', 'utf-8');
+		});
+
+		it('tries to load and parse txt files', () => {
+			prepareArguments([
+				'some/path/to/list.txt'
+			]);
+			expect(fs.readFileSync).toHaveBeenCalled();
+			expect(fs.readFileSync).toHaveBeenCalledWith('some/path/to/list.txt', 'utf-8');
+		});
+	});
+
+	describe('prepare-viewports', () => {
+		it('return empty array when no match', () => {
+			expect(prepareViewports('13456789').length).toBe(0);
+		});
+		it('support hardcoded cases', () => {
+			const cases = [
+				'desktop',
+				'touch',
+				'mobile',
+				'landscape'
+			];
+			for (var i = 0; i < cases.length; i++) {
+				expect(prepareViewports(cases[i]).length).not.toBe(0);
+			}
+		});
+		it('filter viewports by input', () => {
+			expect(prepareViewports('blackberry').length).not.toBe(0);
+		});
+	});
+});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,6 +41,12 @@ program
 	)
 	.parse(process.argv);
 
+// Exit if no targets
+if (program.args.length === 0) {
+	console.error('  You must specify one or more targets! \n');
+	process.exit();
+}
+
 // Prepare the input arguments
 program.args = prepareArgs(program.args);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,9 +3,7 @@
 import * as path from 'path';
 import banner from './banner';
 import prepareArgs from './utils/prepare-arguments';
-import prepareViewports from './utils/prepare-viewports';
 import * as validators from './utils/validators';
-import {version} from '../package.json';
 
 import WebpageCapture from './index';
 
@@ -19,7 +17,6 @@ console.log(banner);
 // Configure the program
 program
 	.name('webcapture')
-	.version(version)
 	.usage('[options] <targets...>')
 	.option('-d, --debug', 'Enable the debug mode to print useful logs')
 	.option('-c, --crop', 'Crop the screenshot as the viewport size')
@@ -39,18 +36,13 @@ program
 		'desktop'
 	)
 	.option(
-		'--viewport-category <name>',
+		'-V, --viewport-category <name>',
 		'Capture all devices included in viewport category'
 	)
 	.parse(process.argv);
 
 // Prepare the input arguments
 program.args = prepareArgs(program.args);
-
-// Get viewport groups by category based on their properties
-if (program.viewportCategory) {
-	program.viewport = prepareViewports(program.viewportCategory);
-}
 
 // Create the UI spinner
 const spinner = ora({
@@ -88,6 +80,7 @@ spinner.start();
 capturer.capture(program.args, {
 	type: program.format,
 	viewport: program.viewport,
+	viewportCategory: program.viewportCategory,
 	captureSelector: program.selector
 }).catch(console.error).then(() => {
 	spinner.stop();

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,9 @@ import mkdirp from 'mkdirp';
 import {performance} from 'perf_hooks';
 import {EventEmitter} from 'events';
 import puppeteer from 'puppeteer';
+
 import devices from './devices';
+import prepareViewports from './utils/prepare-viewports';
 
 const isViewportConform = _.conforms({
 	width: _.isNumber,
@@ -161,6 +163,10 @@ class WebpageCapture extends EventEmitter {
    * Reset all the variables and closes the browser instance
    */
 	async close() {
+		if (!this.browser) {
+			return;
+		}
+
 		await this.browser.close();
 		this.browser = null;
 		this.page = null;
@@ -274,8 +280,12 @@ WebpageCapture.prototype.getViewportObject = function (input) {
 		}
 	} else if (_.isArray(input)) {
 		viewport = input.map(v => this.getViewportObject(v));
-	} else if (_.isObject(input) && isViewportConform(input)) {
-		viewport = {viewport: input};
+	} else if (_.isObject(input)) {
+		if (isViewportConform(input)) {
+			viewport = {viewport: input};
+		} else {
+			viewport = input;
+		}
 	} else if (_.isNumber(input)) {
 		viewport = {
 			viewport: {
@@ -294,12 +304,17 @@ WebpageCapture.prototype.getViewportObject = function (input) {
  * render the output for each desired viewport and settings combination
  */
 WebpageCapture.prototype.run = async function (source, options) {
-	if (!options.viewport) {
+	if (options.viewportCategory) {
+		options.viewport = prepareViewports(options.viewportCategory);
+	}
+
+	if (!options.viewport || options.viewport.length === 0) {
 		return this.render(source, options);
 	}
 
 	// If viewport is not valid skip this run
 	let viewports = this.getViewportObject(options.viewport);
+	// process.exit();
 	if (!viewports) {
 		this.emit('capture:warn', `Invalid viewport ${viewports} skipping ${source}`);
 		return;

--- a/lib/utils/prepare-viewports.js
+++ b/lib/utils/prepare-viewports.js
@@ -2,7 +2,8 @@ import * as _ from 'lodash';
 import devices from '../devices';
 
 export default function (input) {
-	let arr = null;
+	let arr = [];
+
 	switch (input) {
 		case 'desktop':
 			arr = _.filter(devices, ['viewport.isMobile', false]);
@@ -16,9 +17,11 @@ export default function (input) {
 		case 'landscape':
 			arr = _.filter(devices, ['viewport.isLandscape', true]);
 			break;
-		default:
-			console.log('Invalid viewport category', input);
+		default: {
+			const reg = new RegExp(input, 'gi');
+			arr = _.filter(devices, d => d.name.match(reg));
 			break;
+		}
 	}
 
 	return arr;


### PR DESCRIPTION
When using viewportCategory option, both on cli and module usage, the viewport will be populated using the result of the viewportCategory function which filter by default the viewports selecting hard-coded cases such as __desktop__, __mobile__, etc.. or result of custom __name filtering__ if called with an input that is not one of the hard-coded choices.

If __viewport__ option is specified it will override the __viewportCategory__ option.